### PR TITLE
Gracefully handle missing secrets in Dependabot PRs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,15 @@ then
 fi
 REPOSITORY_PATH="${INPUT_REPOSITORY_PATH}"
 
+if test -z "$INPUT_KEY" && test -z "$INPUT_SECRET" && test "$GITHUB_ACTOR" = "dependabot[bot]"
+then
+  echo "::warning ::No value available for the 'key' parameter or the 'secret' parameter. Skipping upload to BuildPulse."
+  echo "⚠️ ⚠️ ⚠️ As of March 1, 2021, Dependabot PRs cannot access secrets in GitHub Actions. See details on the GitHub blog at https://git.io/Jm5au"
+  echo "⚠️ ⚠️ ⚠️ Secrets are necessary in order to authenticate with external services like BuildPulse."
+  echo "⚠️ ⚠️ ⚠️ Since secrets aren't available in this build, the build cannot authenticate with BuildPulse to upload test results."
+  exit 0
+fi
+
 wget --quiet https://github.com/buildpulse/test-reporter/releases/latest/download/test-reporter-linux-amd64 --output-document ./buildpulse-test-reporter
 
 chmod +x ./buildpulse-test-reporter


### PR DESCRIPTION
As [recently announced on the GitHub blog](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/), Dependabot pull requests can no longer access [secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) in when running GitHub Actions workflows. When a workflow needs to authenticate with an external service (like buildpulse.io), the workflow typically uses secrets to store the credentials. As a result of this recent change, when the workflow for a Dependabot pull request tries to upload results to BuildPulse, it now fails due to missing secrets.

Of course, if you're using buildpulse.io to help you track down flaky tests, the last thing you want is for your builds to have *another* reason to fail. 🙈 So, with this pull request, we teach the BuildPulse GitHub Action to gracefully detect missing secrets in a Dependabot PR and emit a warning about the inability to upload results to BuildPulse:

| Before | After |
| --- | --- |
|<img width="1679" alt="Screen Shot 2021-03-21 at 11 01 40 AM" src="https://user-images.githubusercontent.com/2988/111910268-12500300-8a37-11eb-8412-24a35b7a5e89.png">|<img width="1679" alt="Screen Shot 2021-03-21 at 11 03 56 AM" src="https://user-images.githubusercontent.com/2988/111910376-7bd01180-8a37-11eb-8dda-15019e89c917.png">|

In addition to the warning provided in the logs, the warning is also present as an annotation on the job for easier discovery. [[screenshot](https://user-images.githubusercontent.com/2988/111910307-390e3980-8a37-11eb-8f98-f45b8d5cc58e.png)]



