### PR TITLE
Add support for running on macOS and Windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM alpine:3.14
-
-RUN apk add curl
-
-COPY entrypoint.sh /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ Easily connect your GitHub Actions CI workflows to [BuildPulse][buildpulse.io] t
         secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
     ```
 
-     🍎🪟 Need to run jobs on macOS or Windows? Use our [macOS upload step][] or [Windows upload step][] instead.
-
 ## Inputs
 
 ### `account`
@@ -58,5 +56,3 @@ _Optional_ The path to the local git clone of the repository (default: ".").
 
 
 [buildpulse.io]: https://buildpulse.io
-[macos upload step]: https://github.com/buildpulse/test-reporter/blob/4ef5020279a9857708b9e2538e6df99a16185947/.github/workflows/demo.yml#L55-L63
-[windows upload step]: https://github.com/buildpulse/test-reporter/blob/4ef5020279a9857708b9e2538e6df99a16185947/.github/workflows/demo.yml#L82-L89

--- a/action.yml
+++ b/action.yml
@@ -55,8 +55,15 @@ inputs:
     default: "."
     required: false
 runs:
-  using: docker
-  image: Dockerfile
-  env:
-    INPUT_CLI_URL: ${{ inputs.cli-url }} # Translate kebab-case input to snake_case env var
-    INPUT_REPOSITORY_PATH: ${{ inputs.repository-path }} # Translate kebab-case input to snake_case env var
+  using: composite
+  steps:
+    - run: $GITHUB_ACTION_PATH/run.sh
+      shell: bash
+      env:
+        INPUT_ACCOUNT: ${{ inputs.account }}
+        INPUT_REPOSITORY: ${{ inputs.repository }}
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_KEY: ${{ inputs.key }}
+        INPUT_SECRET: ${{ inputs.secret }}
+        INPUT_CLI_URL: ${{ inputs.cli-url }} # Translate kebab-case input to snake_case env var
+        INPUT_REPOSITORY_PATH: ${{ inputs.repository-path }} # Translate kebab-case input to snake_case env var

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
-#!/bin/sh -el
+#!/bin/bash
 
-set -e
+set -ex
 
 if ! echo $INPUT_ACCOUNT | egrep -q '^[0-9]+$'
 then
@@ -45,7 +45,22 @@ then
   exit 0
 fi
 
-CLI_URL="${INPUT_CLI_URL:-https://get.buildpulse.io/test-reporter-linux-amd64}"
+case "$RUNNER_OS" in
+  Linux)
+    BUILDPULSE_TEST_REPORTER_BINARY=test-reporter-linux-amd64
+    ;;
+  macOS)
+    BUILDPULSE_TEST_REPORTER_BINARY=test-reporter-darwin-amd64
+    ;;
+  Windows)
+    BUILDPULSE_TEST_REPORTER_BINARY=test-reporter-windows-amd64.exe
+    ;;
+  *)
+    echo "::error::Unrecognized operating system. Expected RUNNER_OS to be one of \"Linux\", \"macOS\", or \"Windows\", but it was \"$RUNNER_OS\"."
+    exit 1
+esac
+
+CLI_URL="${INPUT_CLI_URL:-https://get.buildpulse.io/$BUILDPULSE_TEST_REPORTER_BINARY}"
 
 curl -fsSL --retry 3 --retry-connrefused "${CLI_URL}" > ./buildpulse-test-reporter
 


### PR DESCRIPTION
Prior to this change, this action was a Docker-based action (i.e., a "container action"). As seen in #2, container actions only run on Linux.

In this pull request, we switch to using a "composite action", which allows us to run on all three of the operating systems supported by GitHub Actions: Linux, macOS, and Windows.

Shout-out to @janpio for [introducing me to the concept of composite actions](https://github.com/Workshop64/buildpulse-action/issues/2#issuecomment-1051057446)! 🙌 :beers: 